### PR TITLE
Added basic version of the Footer

### DIFF
--- a/TEMPDATA/footer.es6
+++ b/TEMPDATA/footer.es6
@@ -1,0 +1,100 @@
+export default {
+  customer: [
+    {
+      title: 'Subscribe',
+      href: 'http://www.economistgroupmedia.com',
+    },
+    {
+      title: 'Contact us',
+      href: 'http://www.economist.com/rights/',
+    },
+    {
+      title: 'Help',
+      href: 'http://www.economist.com/rights/',
+    },
+  ],
+  economist: [
+    {
+      title: 'Advertise',
+      href: 'products/subscribe',
+    },
+    {
+      title: 'Editorial Staff',
+      href: 'node/21013093',
+    },
+    {
+      title: 'Reprints',
+      href: 'node/21017280',
+    },
+    {
+      title: 'Site Map',
+      href: 'node/21554326',
+    },
+    {
+      title: 'Careers',
+      href: 'node/21013080',
+    }
+  ],
+  social: [
+    {
+      title: 'Facebook',
+      meta: 'facebook',
+      href: 'https://www.economist.com',
+      internal: false,
+    },
+    {
+      title: 'Twitter',
+      meta: 'twitter',
+      href: 'https://www.economist.com',
+      internal: false,
+    },
+    {
+      title: 'Linkedin',
+      meta: 'linkedin',
+      href: 'https://www.economist.com',
+      internal: false,
+    },
+    {
+      title: 'Google',
+      meta: 'googleplus',
+      href: 'https://www.economist.com',
+      internal: false,
+    },
+    {
+      title: 'Tumblr',
+      meta: 'tumblr',
+      href: 'https://www.economist.com',
+      internal: false,
+    },
+    {
+      title: 'Instagram',
+      meta: 'instagram',
+      href: 'https://www.economist.com',
+      internal: false,
+    },
+    {
+      title: 'mail',
+      meta: 'mail',
+      href: 'https://www.economist.com',
+      internal: true,
+    },
+  ],
+  business: [
+    {
+      title: 'Terms of Use',
+      href: 'node/21013093',
+    },
+    {
+      title: 'Privacy',
+      href: 'node/21554326',
+    },
+    {
+      title: 'Cookies',
+      href: 'http://www.economistgroup.com/results_and_governance/governance/privacy',
+    },
+    {
+      title: 'Accessibility',
+      href: 'http://www.economistgroup.com/results_and_governance/governance/privacy',
+    },
+  ],
+};

--- a/app.es6
+++ b/app.es6
@@ -1,5 +1,6 @@
 import React from 'react';
 import DefaultAppHeader from './header';
+import DefaultAppFooter from './footer';
 import {
   AppContainer as DefaultAppContainer,
   AppContentContainer as DefaultAppContentContainer,
@@ -12,6 +13,7 @@ export default function AppTemplate({
     AppContainer: DefaultAppContainer,
     AppHeader: DefaultAppHeader,
     AppContentContainer: DefaultAppContentContainer,
+    AppFooter: DefaultAppFooter,
   },
   ...remainingProps,
 } = {}) {

--- a/footer.css
+++ b/footer.css
@@ -1,0 +1,1 @@
+@import '@economist/component-footer';

--- a/footer.es6
+++ b/footer.es6
@@ -1,0 +1,9 @@
+import React, { PropTypes } from 'react';
+import Footer from '@economist/component-footer';
+import data from './TEMPDATA/footer';
+
+export default function AppFooter() {
+  return (
+    <Footer data={data} />
+  );
+}

--- a/index.css
+++ b/index.css
@@ -2,6 +2,7 @@
 @import '@economist/component-font-officina';
 @import '@economist/component-404';
 @import './header';
+@import './footer';
 @import '@economist/component-win-articlepage';
 @import '@economist/component-win-homepage';
 

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "@economist/component-404": "^3.0.0",
     "@economist/component-font-neutra2": "^1.0.4",
     "@economist/component-font-officina": "^1.0.0",
+    "@economist/component-footer": "^1.3.7",
     "@economist/component-grid": "^1.3.0",
     "@economist/component-icon": "^3.0.4",
     "@economist/component-palette": "^1.3.0",
@@ -141,8 +142,8 @@
     "@economist/component-win-articlepage": "^1.0.0",
     "@economist/component-win-homepage": "^1.0.0",
     "@economist/component-win-navigation": "^1.0.1",
-    "node-fetch": "^1.3.3",
     "isomorphic-fetch": "^2.2.0",
+    "node-fetch": "^1.3.3",
     "react": "^0.14.1",
     "react-router-component": "^0.27.2",
     "react-sticky-position": "^2.0.0"


### PR DESCRIPTION
After implement the real data fetcher please remove the TEMPDATA folder.
The @econonomist/component-footer needs some refactor to be reusable, for example the quote should be optional.