### PR TITLE
Navigation works without JavaScript being switched on

### DIFF
--- a/example.es6
+++ b/example.es6
@@ -13,5 +13,5 @@ const TrackedApp = setupI13n(WorldInApp, {
   isViewportEnabled: true,
 }, [ new ReactI13nOmniture(OmnitureConfig) ]);
 export default (
-  <TrackedApp path="/article/10501" />
+  <TrackedApp path="/article/10501?navigation=true&category=leaders" />
 );

--- a/header.es6
+++ b/header.es6
@@ -78,7 +78,7 @@ function cacheMenu() {
   return cache('/api/menu');
 }
 
-export default function AppHeaderWithData(props) {
+export default function AppHeaderWithData(props = {}) {
   return (
     <Impart.RootContainer
       {...props}

--- a/header.es6
+++ b/header.es6
@@ -3,6 +3,7 @@ import React, { PropTypes } from 'react';
 import StickyPosition from 'react-sticky-position';
 import Navigation from '@economist/component-win-navigation';
 import Icon from '@economist/component-icon';
+import { extract, parse } from 'query-string';
 
 import Impart from '@economist/component-react-async-container';
 import cache from '@economist/component-react-async-container/cache';
@@ -10,12 +11,14 @@ import fetch from './fetch';
 import loadingHandler from './loading-handler';
 import failureHandler from './failure-handler';
 
-function AppHeader({ navigationItems }) {
-  const focusCategorySlug = null;
-  const focusSubcategorySlug = null;
-  const activeCategorySlug = null;
-  const activeSubcategorySlug = null;
-  const activeArticleId = null;
+function AppHeader({ path, navigationItems }) {
+  const queryString = extract(path);
+  const query = queryString ? parse(queryString) : {};
+  const focusNavigation = query.navigation || false;
+  const focusCategorySlug = query.category || null;
+  const focusSubcategorySlug = query.subcategory || null;
+  const id = (path.match(/\d+/) || []).pop();
+  const activeArticleId = id ? Number(id) : null;
   return (
     <StickyPosition className="world-in-header world-in-header--sticked">
       <div className="world-in-header__inner-wrapper">
@@ -46,10 +49,9 @@ function AppHeader({ navigationItems }) {
             <div className="world-in-header__main-navigation">
               <Navigation
                 navigationItems={navigationItems}
+                focusNavigation={focusNavigation}
                 focusCategorySlug={focusCategorySlug}
                 focusSubcategorySlug={focusSubcategorySlug}
-                activeCategorySlug={activeCategorySlug}
-                activeSubcategorySlug={activeSubcategorySlug}
                 activeArticleId={activeArticleId}
               />
             </div>
@@ -76,9 +78,10 @@ function cacheMenu() {
   return cache('/api/menu');
 }
 
-export default function AppHeaderWithData() {
+export default function AppHeaderWithData(props) {
   return (
     <Impart.RootContainer
+      {...props}
       Component={AppHeader}
       cache={cacheMenu}
       route={fetchMenu}

--- a/index.es6
+++ b/index.es6
@@ -13,6 +13,10 @@ export default class WorldInApp extends Component {
     path: PropTypes.string.isRequired,
   }
 
+  static defaultProps = {
+    path: '/',
+  }
+
   render() {
     const { path, ...remainingProps } = this.props;
     return (

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "@economist/component-win-navigation": "^1.2.0",
     "@economist/react-i13n-omniture": "^1.1.3",
     "isomorphic-fetch": "^2.2.0",
+    "query-string": "^3.0.0",
     "react": "^0.14.3",
     "react-router-component": "^0.27.2",
     "react-sticky-position": "the-economist-editorial/react-sticky-position",


### PR DESCRIPTION
Navigation works without JavaScript being switched on. If query strings are passed through from `win-website` and `connect-react-html-template` (not currently the case, however I have tested it and have some PRs ready for that; both now attached to the bottom.)