### PR TITLE
Updated i13n dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "@economist/component-win-homepage": "^1.2.1",
     "@economist/component-win-navigation": "^1.3.1",
     "@economist/component-win-sharebar": "^1.0.4",
-    "@economist/react-i13n-omniture": "^1.1.3",
+    "@economist/react-i13n-omniture": "^1.2.0",
     "isomorphic-fetch": "^2.2.0",
     "react": "^0.14.3",
     "react-router-component": "^0.28.0",
@@ -183,7 +183,7 @@
     "parallelshell": "^2.0.0",
     "pre-commit": "^1.0.10",
     "react-dom": "^0.14.3",
-    "react-i13n": "^0.2.0-rc1",
+    "react-i13n": "^2.0.2",
     "watchify": "^3.4.0"
   },
   "pre-commit": [


### PR DESCRIPTION
our i13n stuff has had it's dependencies updated and that's caused our deployment to break so have updated the dependencies.