### PR TITLE
Updated win-cover dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "@economist/component-palette": "^1.3.0",
     "@economist/component-react-async-container": "^1.3.0",
     "@economist/component-win-articlepage": "^1.11.0",
-    "@economist/component-win-cover": "2.0.0",
+    "@economist/component-win-cover": "^2.0.2",
     "@economist/component-win-homepage": "^1.2.1",
     "@economist/component-win-navigation": "^1.3.1",
     "@economist/component-win-sharebar": "^1.0.4",


### PR DESCRIPTION
No caret on version for win-cover so it hasn't been minor/patch versions. 